### PR TITLE
Ignore test packages, logs, and linting

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
 package-lock.json
+newrelic_agent.log
+**/node_modules/**
+.eslint*


### PR DESCRIPTION
Fixes #4 

Previous package details:
```
npm notice === Tarball Contents ===
    !!!WAY TOO MANY FILES!!!
npm notice === Tarball Details ===
npm notice name:          @newrelic/superagent
npm notice version:       1.0.0
npm notice package size:  1.1 MB
npm notice unpacked size: 20.2 MB
npm notice shasum:        0104006244f01ef28133fb7302f268bad38eecfb
npm notice integrity:     sha512-06dmrrnkWmOkE[...]LsQw7cRuj7/Og==
npm notice total files:   234
```

New package details:
```
npm notice === Tarball Contents ===
npm notice 825B  package.json
npm notice 427B  .travis.yml
npm notice 138B  CHANGELOG.md
npm notice 372B  index.js
npm notice 130B  nr-hooks.js
npm notice 948B  README.md
npm notice 1.8kB lib/instrumentation.js
npm notice 368B  tests/unit/newrelic.js
npm notice 594B  tests/unit/superagent.tap.js
npm notice 1.1kB tests/versioned/async-await.tap.js
npm notice 368B  tests/versioned/newrelic.js
npm notice 424B  tests/versioned/package.json
npm notice 1.5kB tests/versioned/superagent.tap.js
npm notice === Tarball Details ===
npm notice name:          @newrelic/superagent
npm notice version:       1.0.0
npm notice package size:  3.1 kB
npm notice unpacked size: 9.1 kB
npm notice shasum:        ccaf3a4404a484320845cd057a817347b81a579e
npm notice integrity:     sha512-sOJm3TzwWESXG[...]2nV3rJK76wjCQ==
npm notice total files:   13
```

This leaves the tests and changelog included. The latter because I appreciate when changelogs are included with packages. The former because they are needed for the agent (newrelic/node-newrelic) to run against changes.