### PR TITLE
pinned versioned tests for node v4 and v5 to superagent v<4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "newrelic": "^4.3.0",
     "semver": "^5.5.0",
     "superagent": "^3.8.3",
-    "tap": "^12.0.1"
+    "tap": "^11.0.0"
   },
   "peerDependencies": {
     "newrelic": ">=4.3.0"

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -4,7 +4,17 @@
   "private": true,
   "tests": [{
     "engines": {
-      "node": "<8.1"
+      "node": "<6"
+    },
+    "dependencies": {
+      "superagent": ">=2 <4"
+    },
+    "files": [
+      "superagent.tap.js"
+    ]
+  }, {
+    "engines": {
+      "node": ">=6 <8.1"
     },
     "dependencies": {
       "superagent": ">=2"


### PR DESCRIPTION
as of v4, superagent no longer supports node on versions <6.

https://github.com/visionmedia/superagent/releases/tag/v4.0.0