### PR TITLE
changes branch for coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://coveralls.io/repos/github/newrelic/node-newrelic-superagent/badge.svg?branch=master)](https://coveralls.io/github/newrelic/node-newrelic-superagent?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/newrelic/node-newrelic-superagent/badge.svg?branch=main)](https://coveralls.io/github/newrelic/node-newrelic-superagent?branch=main)
 
 New Relic's official `superagent` instrumentation for use with the
 [Node agent](https://github.com/newrelic/node-newrelic). This module is a


### PR DESCRIPTION
* Changes branch for Coveralls badge to match new default.

There's a good chance this won't work. I think we'll need/want to just drop Coveralls again unless we want to get setup differently.

Deliberately targeting main to exercise everything (PR -> CI -> Merge main). Afterwards, I'll merge the change into the staging branch.