### PR TITLE
Removed usage of Coveralls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Coverage Status](https://coveralls.io/repos/github/newrelic/node-newrelic-superagent/badge.svg?branch=main)](https://coveralls.io/github/newrelic/node-newrelic-superagent?branch=main)
-
 New Relic's official `superagent` instrumentation for use with the
 [Node agent](https://github.com/newrelic/node-newrelic). This module is a
 dependency of the agent and is installed with it by running:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -19,7 +19,6 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 **[devDependencies](#devDependencies)**
 
 * [@newrelic/test-utilities](#newrelictest-utilities)
-* [coveralls](#coveralls)
 * [eslint](#eslint)
 * [newrelic](#newrelic)
 * [semver](#semver)
@@ -112,40 +111,6 @@ PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a condition to your use of
 these files, you are solely responsible for such use. New Relic will have no
 liability to you for direct, indirect, consequential, incidental, special, or
 punitive damages or for lost profits or data.
-
-```
-
-### coveralls
-
-This product includes source derived from [coveralls](https://github.com/nickmerwin/node-coveralls) ([v3.1.0](https://github.com/nickmerwin/node-coveralls/tree/v3.1.0)), distributed under the [BSD-2-Clause License](https://github.com/nickmerwin/node-coveralls/blob/v3.1.0/LICENSE):
-
-```
-Copyright (c) 2013, Coveralls, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies,
-either expressed or implied, of Coveralls, LLC.
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@newrelic/test-utilities": "^3.3.0",
-    "coveralls": "^3.0.2",
     "eslint": "^6.8.0",
     "newrelic": "^6.11.0",
     "semver": "^5.5.0",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Jul 14 2020 10:10:36 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Tue Jul 14 2020 14:53:21 GMT-0700 (Pacific Daylight Time)",
   "projectName": "New Relic SuperAgent Instrumentation",
   "projectUrl": "https://github.com/newrelic/node-newrelic-superagent",
   "includeDev": true,
@@ -32,18 +32,6 @@
       "FOR_REVIEW": [
         "Unable to determine source for license text."
       ]
-    },
-    "coveralls@3.1.0": {
-      "name": "coveralls",
-      "version": "3.1.0",
-      "range": "^3.0.2",
-      "licenses": "BSD-2-Clause",
-      "repoUrl": "https://github.com/nickmerwin/node-coveralls",
-      "versionedRepoUrl": "https://github.com/nickmerwin/node-coveralls/tree/v3.1.0",
-      "licenseFile": "node_modules/coveralls/LICENSE",
-      "licenseUrl": "https://github.com/nickmerwin/node-coveralls/blob/v3.1.0/LICENSE",
-      "licenseTextSource": "file",
-      "publisher": "Gregg Caines"
     },
     "eslint@6.8.0": {
       "name": "eslint",


### PR DESCRIPTION
* Removed usage of Coveralls.

Closes: https://github.com/newrelic/node-newrelic-superagent/issues/42.