### PR TITLE
7.1.1 was released, updating semver range to only exclude 7.1.0

### DIFF
--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -7,7 +7,7 @@
       "node": ">=12"
     },
     "dependencies": {
-      "superagent": ">=2 <7.1.0"
+      "superagent": ">=2 <7.1.0 ||  >=7.1.1"
     },
     "files": [
       "async-await.tap.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated semver ranges to exclude `7.1.0` as it is a broken version.
