### PR TITLE
Dropped Node 12.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # Visual Studio Code files
 .vscode
+
+# JetBrains files
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "node": ">=14.0"
       },
       "peerDependencies": {
-        "newrelic": ">=6.11.0"
+        "newrelic": ">=8.7.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "tap": "^16.0.1"
       },
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       },
       "peerDependencies": {
         "newrelic": ">=6.11.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node": ">=14.0"
   },
   "peerDependencies": {
-    "newrelic": ">=6.11.0"
+    "newrelic": ">=8.7.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tap": "^16.0.1"
   },
   "engines": {
-    "node": ">=12.0"
+    "node": ">=14.0"
   },
   "peerDependencies": {
     "newrelic": ">=6.11.0"

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "tests": [{
     "engines": {
-      "node": ">=12"
+      "node": ">=14"
     },
     "dependencies": {
       "superagent": ">=2 <7.1.0 ||  >=7.1.1"

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Apr 11 2022 12:12:05 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Tue Jul 26 2022 10:03:52 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic SuperAgent Instrumentation",
   "projectUrl": "https://github.com/newrelic/node-newrelic-superagent",
   "includeOptDeps": false,

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Jul 26 2022 10:03:52 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Tue Jul 26 2022 10:22:20 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic SuperAgent Instrumentation",
   "projectUrl": "https://github.com/newrelic/node-newrelic-superagent",
   "includeOptDeps": false,


### PR DESCRIPTION
Signed-off-by: mrickard <maurice@mauricerickard.com>

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
Updated the minimum version of the newrelic agent peer dependency to be `>=8.7.0`.

## Links
https://issues.newrelic.com/browse/NR-35638

## Details
Dropped Node 12 support.
Added JetBrains files to .gitignore.