### PR TITLE
Add versioned test sampling config to package.json

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1081,7 +1081,7 @@ This product includes source derived from [lockfile-lint](https://github.com/lir
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v8.17.1](https://github.com/newrelic/node-newrelic/tree/v8.17.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v8.17.1/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v10.0.0](https://github.com/newrelic/node-newrelic/tree/v10.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v10.0.0/LICENSE):
 
 ```
                                  Apache License

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "husky": "^7.0.2",
         "lint-staged": "^11.1.2",
         "lockfile-lint": "^4.9.6",
-        "newrelic": "^8.1.0",
+        "newrelic": "^10.0.0",
         "prettier": "^2.3.2",
         "semver": "^5.5.0",
         "superagent": "^3.8.3",
@@ -424,6 +424,21 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@contrast/fn-inspect": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.0.tgz",
+      "integrity": "sha512-iulijoAuhfamXZNWsEy4ORNd8TxqD6aKeMiukDpWSwuRJ3sB+4lOmY2DkP2WwlBpYMmh3k4/7LHP2I925Y2xKQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.16.0",
+        "node-gyp-build": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -445,9 +460,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.0.tgz",
-      "integrity": "sha512-ySMTXQuMvvswoobvN+0LsaPf7ITO2JVfJmHxQKI4cGehNrrUms+n81BlHEX7Hl/LExji6XE3fnI9U04GSkRruA==",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
+      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
       "dev": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
@@ -457,65 +472,16 @@
         "node": "^8.13.0 || >=10.10.0"
       }
     },
-    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz",
-      "integrity": "sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==",
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.6.tgz",
+      "integrity": "sha512-QyAXR8Hyh7uMDmveWxDSUcJr9NAWaZ2I6IXgAYvQmfflwouTM+rArE2eEaCtLlRqO81j7pRLCt81IefUei6Zbw==",
       "dev": true,
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
         "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/protobufjs/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-      "dev": true
-    },
-    "node_modules/@grpc/proto-loader": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
-      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
-      "dev": true,
-      "dependencies": {
-        "@types/long": "^4.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.3",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -679,33 +645,15 @@
       }
     },
     "node_modules/@newrelic/aws-sdk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-4.1.2.tgz",
-      "integrity": "sha512-B83gZDS6eseNAMd41s8FTyd+JSxKHl4cN8kQnh1k5aYe0XB/Mi3hxn0/mxGzui84L4kL0GJCCg/UOg+A2ciSQg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-5.0.4.tgz",
+      "integrity": "sha512-543TkE+irlcXjxMeQV37d3JSSAn8mGTbRV9EWQEcXagDM7EVFaBtsUodU/P7H6Zp6issmxBA3z2XGLcpbgkbVQ==",
       "dev": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "newrelic": ">=6.11.0"
-      }
-    },
-    "node_modules/@newrelic/aws-sdk/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "newrelic": ">=8.7.0"
       }
     },
     "node_modules/@newrelic/eslint-config": {
@@ -726,31 +674,31 @@
       }
     },
     "node_modules/@newrelic/koa": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-6.1.2.tgz",
-      "integrity": "sha512-nmjr5hv+nRDC2NaRF4+iex41K6iJ/UCujgnj8oyht1grazJXQHq0dJZdMxUVNMMO+m4ukTeisSlI4d/H/W9JUw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-7.2.0.tgz",
+      "integrity": "sha512-3y/CCOLJ6sEPTKyQAmBrBP5CfZ5ak8mWt+7mWjdbblOXQh20LEsrA/KQAh/ROcTh6rV8oxsubLZ3N13LIeIoVQ==",
       "dev": true,
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "newrelic": ">=6.11.0"
       }
     },
     "node_modules/@newrelic/native-metrics": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-8.0.0.tgz",
-      "integrity": "sha512-df/V1P6dxpX09PaA6Jx9pmkPbRrue5hDyRCc4w3bnqMbnybvwVwS+q1/QEPvjBPQJ5abTRlBcJ7UZ3sfGW1hzg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-9.0.0.tgz",
+      "integrity": "sha512-WYDRs4hlFerUyism2TjF1PIJfP8w50Nc9Kt61zWNrGM3QYOrKXZ5ibA3R0fQgU0+LM7UWtQ9g7onFpVUGsj8QQ==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
-        "nan": "^2.15.0",
+        "nan": "^2.16.0",
         "semver": "^5.5.1"
       },
       "engines": {
-        "node": ">=12",
+        "node": ">=14",
         "npm": ">=6"
       }
     },
@@ -797,12 +745,12 @@
       }
     },
     "node_modules/@newrelic/superagent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-5.1.1.tgz",
-      "integrity": "sha512-Bp2QtknriKHLKSfrBRyg4PjGJ8CCSkxYfZEDppOWmrGukJAP/9Vvr+ya0Mmj7SU8eIMMhaTvAnjvb2mVmX8wBw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-6.0.0.tgz",
+      "integrity": "sha512-5nClQp9ACd4BvLusAgFHjjKLDgAaC+dKmIsRNOPC82LOLFaoOgxxtbecnDIJ0NWCKQS+WOdmXdgYutwH+e5dsA==",
       "dev": true,
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       },
       "peerDependencies": {
         "newrelic": ">=6.11.0"
@@ -2948,9 +2896,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
+      "version": "18.16.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
+      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -3237,6 +3185,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -5466,6 +5423,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -6204,22 +6170,22 @@
       }
     },
     "node_modules/newrelic": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.17.1.tgz",
-      "integrity": "sha512-7KJQaTTszlX2DaHRFXgvhG1Ebt0sR57ix5PXw/06dALP2G2f+5B9VBI2QenYuiwwebcw9KcxI07+yQRjF46fWg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-10.0.0.tgz",
+      "integrity": "sha512-FyXsJMUApTVG+neypymDIDcBAdy8CwAmVmaa2gqLektLuX6Z77pKSLOBfpanhTgFEe/XS23tgsnEqx2eOF+GDw==",
       "dev": true,
       "dependencies": {
-        "@grpc/grpc-js": "^1.5.5",
-        "@grpc/proto-loader": "^0.6.13",
-        "@newrelic/aws-sdk": "^4.1.1",
-        "@newrelic/koa": "^6.1.1",
-        "@newrelic/superagent": "^5.1.0",
+        "@grpc/grpc-js": "^1.8.10",
+        "@grpc/proto-loader": "^0.7.5",
+        "@newrelic/aws-sdk": "^5.0.2",
+        "@newrelic/koa": "^7.1.1",
+        "@newrelic/superagent": "^6.0.0",
         "@tyriar/fibonacci-heap": "^2.0.7",
-        "async": "^3.2.3",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
+        "json-bigint": "^1.0.0",
         "json-stringify-safe": "^5.0.0",
-        "readable-stream": "^3.6.0",
+        "readable-stream": "^3.6.1",
         "semver": "^5.3.0",
         "winston-transport": "^4.5.0"
       },
@@ -6227,18 +6193,13 @@
         "newrelic-naming-rules": "bin/test-naming-rules.js"
       },
       "engines": {
-        "node": ">=12.0.0",
+        "node": ">=14",
         "npm": ">=6.0.0"
       },
       "optionalDependencies": {
-        "@newrelic/native-metrics": "^8.0.0"
+        "@contrast/fn-inspect": "^3.3.0",
+        "@newrelic/native-metrics": "^9.0.0"
       }
-    },
-    "node_modules/newrelic/node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-      "dev": true
     },
     "node_modules/newrelic/node_modules/concat-stream": {
       "version": "2.0.0",
@@ -6256,9 +6217,9 @@
       }
     },
     "node_modules/newrelic/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6274,6 +6235,18 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -7052,9 +7025,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
+      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -7068,14 +7041,18 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "dev": true
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -10707,6 +10684,17 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true
     },
+    "@contrast/fn-inspect": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.0.tgz",
+      "integrity": "sha512-iulijoAuhfamXZNWsEy4ORNd8TxqD6aKeMiukDpWSwuRJ3sB+4lOmY2DkP2WwlBpYMmh3k4/7LHP2I925Y2xKQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.16.0",
+        "node-gyp-build": "^4.4.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -10725,68 +10713,25 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.0.tgz",
-      "integrity": "sha512-ySMTXQuMvvswoobvN+0LsaPf7ITO2JVfJmHxQKI4cGehNrrUms+n81BlHEX7Hl/LExji6XE3fnI9U04GSkRruA==",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
+      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
       "dev": true,
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
-      },
-      "dependencies": {
-        "@grpc/proto-loader": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz",
-          "integrity": "sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==",
-          "dev": true,
-          "requires": {
-            "@types/long": "^4.0.1",
-            "lodash.camelcase": "^4.3.0",
-            "long": "^4.0.0",
-            "protobufjs": "^7.0.0",
-            "yargs": "^16.2.0"
-          }
-        },
-        "protobufjs": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-          "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          },
-          "dependencies": {
-            "long": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-              "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-              "dev": true
-            }
-          }
-        }
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
-      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.6.tgz",
+      "integrity": "sha512-QyAXR8Hyh7uMDmveWxDSUcJr9NAWaZ2I6IXgAYvQmfflwouTM+rArE2eEaCtLlRqO81j7pRLCt81IefUei6Zbw==",
       "dev": true,
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.11.3",
+        "protobufjs": "^7.0.0",
         "yargs": "^16.2.0"
       }
     },
@@ -10910,24 +10855,11 @@
       }
     },
     "@newrelic/aws-sdk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-4.1.2.tgz",
-      "integrity": "sha512-B83gZDS6eseNAMd41s8FTyd+JSxKHl4cN8kQnh1k5aYe0XB/Mi3hxn0/mxGzui84L4kL0GJCCg/UOg+A2ciSQg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-5.0.4.tgz",
+      "integrity": "sha512-543TkE+irlcXjxMeQV37d3JSSAn8mGTbRV9EWQEcXagDM7EVFaBtsUodU/P7H6Zp6issmxBA3z2XGLcpbgkbVQ==",
       "dev": true,
-      "requires": {
-        "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
+      "requires": {}
     },
     "@newrelic/eslint-config": {
       "version": "0.0.2",
@@ -10937,21 +10869,21 @@
       "requires": {}
     },
     "@newrelic/koa": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-6.1.2.tgz",
-      "integrity": "sha512-nmjr5hv+nRDC2NaRF4+iex41K6iJ/UCujgnj8oyht1grazJXQHq0dJZdMxUVNMMO+m4ukTeisSlI4d/H/W9JUw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-7.2.0.tgz",
+      "integrity": "sha512-3y/CCOLJ6sEPTKyQAmBrBP5CfZ5ak8mWt+7mWjdbblOXQh20LEsrA/KQAh/ROcTh6rV8oxsubLZ3N13LIeIoVQ==",
       "dev": true,
       "requires": {}
     },
     "@newrelic/native-metrics": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-8.0.0.tgz",
-      "integrity": "sha512-df/V1P6dxpX09PaA6Jx9pmkPbRrue5hDyRCc4w3bnqMbnybvwVwS+q1/QEPvjBPQJ5abTRlBcJ7UZ3sfGW1hzg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-9.0.0.tgz",
+      "integrity": "sha512-WYDRs4hlFerUyism2TjF1PIJfP8w50Nc9Kt61zWNrGM3QYOrKXZ5ibA3R0fQgU0+LM7UWtQ9g7onFpVUGsj8QQ==",
       "dev": true,
       "optional": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",
-        "nan": "^2.15.0",
+        "nan": "^2.16.0",
         "semver": "^5.5.1"
       }
     },
@@ -10989,9 +10921,9 @@
       }
     },
     "@newrelic/superagent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-5.1.1.tgz",
-      "integrity": "sha512-Bp2QtknriKHLKSfrBRyg4PjGJ8CCSkxYfZEDppOWmrGukJAP/9Vvr+ya0Mmj7SU8eIMMhaTvAnjvb2mVmX8wBw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-6.0.0.tgz",
+      "integrity": "sha512-5nClQp9ACd4BvLusAgFHjjKLDgAaC+dKmIsRNOPC82LOLFaoOgxxtbecnDIJ0NWCKQS+WOdmXdgYutwH+e5dsA==",
       "dev": true,
       "requires": {}
     },
@@ -12646,9 +12578,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
+      "version": "18.16.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
+      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==",
       "dev": true
     },
     "@types/parse-json": {
@@ -12865,6 +12797,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
       "dev": true
     },
     "binary-extensions": {
@@ -14510,6 +14448,15 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -15089,33 +15036,28 @@
       "dev": true
     },
     "newrelic": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.17.1.tgz",
-      "integrity": "sha512-7KJQaTTszlX2DaHRFXgvhG1Ebt0sR57ix5PXw/06dALP2G2f+5B9VBI2QenYuiwwebcw9KcxI07+yQRjF46fWg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-10.0.0.tgz",
+      "integrity": "sha512-FyXsJMUApTVG+neypymDIDcBAdy8CwAmVmaa2gqLektLuX6Z77pKSLOBfpanhTgFEe/XS23tgsnEqx2eOF+GDw==",
       "dev": true,
       "requires": {
-        "@grpc/grpc-js": "^1.5.5",
-        "@grpc/proto-loader": "^0.6.13",
-        "@newrelic/aws-sdk": "^4.1.1",
-        "@newrelic/koa": "^6.1.1",
-        "@newrelic/native-metrics": "^8.0.0",
-        "@newrelic/superagent": "^5.1.0",
+        "@contrast/fn-inspect": "^3.3.0",
+        "@grpc/grpc-js": "^1.8.10",
+        "@grpc/proto-loader": "^0.7.5",
+        "@newrelic/aws-sdk": "^5.0.2",
+        "@newrelic/koa": "^7.1.1",
+        "@newrelic/native-metrics": "^9.0.0",
+        "@newrelic/superagent": "^6.0.0",
         "@tyriar/fibonacci-heap": "^2.0.7",
-        "async": "^3.2.3",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
+        "json-bigint": "^1.0.0",
         "json-stringify-safe": "^5.0.0",
-        "readable-stream": "^3.6.0",
+        "readable-stream": "^3.6.1",
         "semver": "^5.3.0",
         "winston-transport": "^4.5.0"
       },
       "dependencies": {
-        "async": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-          "dev": true
-        },
         "concat-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
@@ -15129,9 +15071,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -15146,6 +15088,13 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "dev": true,
+      "optional": true
     },
     "node-preload": {
       "version": "0.2.1",
@@ -15743,9 +15692,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
+      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -15758,9 +15707,16 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+          "dev": true
+        }
       }
     },
     "pump": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
     "lockfile-lint": "^4.9.6",
-    "newrelic": "^8.1.0",
+    "newrelic": "^10.0.0",
     "prettier": "^2.3.2",
     "semver": "^5.5.0",
     "superagent": "^3.8.3",

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -7,7 +7,10 @@
       "node": ">=14"
     },
     "dependencies": {
-      "superagent": ">=2 <7.1.0 ||  >=7.1.1"
+      "superagent": {
+        "versions": ">=2 <7.1.0 ||  >=7.1.1",
+        "samples": 5
+      }
     },
     "files": [
       "async-await.tap.js",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Dec 12 2022 10:25:10 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Wed Apr 26 2023 09:47:02 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic SuperAgent Instrumentation",
   "projectUrl": "https://github.com/newrelic/node-newrelic-superagent",
   "includeOptDeps": false,
@@ -158,15 +158,15 @@
       "email": "liran.tal@gmail.com",
       "url": "https://github.com/lirantal"
     },
-    "newrelic@8.17.1": {
+    "newrelic@10.0.0": {
       "name": "newrelic",
-      "version": "8.17.1",
-      "range": "^8.1.0",
+      "version": "10.0.0",
+      "range": "^10.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v8.17.1",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v10.0.0",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v8.17.1/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v10.0.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
I've changed the sampling to 5 to reduce the number of superagent tests we run in major mode to solve the OOM on versioned test issue. Without this change, we run 7 major versions of superagent, with this change we'll only run five major versions (which is still a lot). Additionally I noticed the devDep newrelic agent was still on v8, so bumped to the latest version (v10).

Successful Run: https://github.com/newrelic/node-newrelic/actions/runs/4802420291
